### PR TITLE
カフェの注文プログラムのバグを修正

### DIFF
--- a/cafe.rb
+++ b/cafe.rb
@@ -19,7 +19,7 @@ def take_order(menus)
     puts "(#{i})#{menu[:name]}: #{menu[:price]}円"
   end
   print '>'
-  order_number = gets.to_i
+  order_number = gets.to_i - 1
   puts "#{menus[order_number][:name]}(#{menus[order_number][:price]}円)ですね。"
   order_number
 end

--- a/cafe.rb
+++ b/cafe.rb
@@ -30,5 +30,5 @@ order1 = take_order(DRINKS)
 puts 'フードメニューはいかがですか?'
 order2 = take_order(FOODS)
 
-total = FOODS[order1][:price] + DRINKS[order2][:price]
+total = DRINKS[order1][:price] + FOODS[order2][:price]
 puts "お会計は#{total}円になります。ありがとうございました！"

--- a/cafe.rb
+++ b/cafe.rb
@@ -5,13 +5,13 @@ DRINKS = [
   { name: 'カフェラテ', price: 400 },
   { name: 'チャイ', price: 460 },
   { name: 'エスプレッソ', price: 340 },
-  { name: '緑茶', price: 450 },
+  { name: '緑茶', price: 450 }
 ].freeze
 
 FOODS = [
   { name: 'チーズケーキ', price: 470 },
   { name: 'アップルパイ', price: 520 },
-  { name: 'ホットサンド', price: 410 },
+  { name: 'ホットサンド', price: 410 }
 ].freeze
 
 def take_order(menus)

--- a/cafe.rb
+++ b/cafe.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
 DRINKS = [
-  { name: 'コーヒー', price: '300' },
-  { name: 'カフェラテ', price: '400' },
-  { name: 'チャイ', price: '460' },
-  { name: 'エスプレッソ', price: '340' },
-  { name: '緑茶', price: '450' }
+  { name: 'コーヒー', price: 300 },
+  { name: 'カフェラテ', price: 400 },
+  { name: 'チャイ', price: 460 },
+  { name: 'エスプレッソ', price: 340 },
+  { name: '緑茶', price: 450 },
 ].freeze
 
 FOODS = [
-  { name: 'チーズケーキ', price: '470' },
-  { name: 'アップルパイ', price: '520' },
-  { name: 'ホットサンド', price: '410' }
+  { name: 'チーズケーキ', price: 470 },
+  { name: 'アップルパイ', price: 520 },
+  { name: 'ホットサンド', price: 410 },
 ].freeze
 
 def take_order(menus)


### PR DESCRIPTION
* [x] メニューデータの `price` を文字列から整数値に変更
* [x] 対話プログラムで受け取った数字をメニュー配列のインデックス番号と一致させる
* [x] 金額を合算する箇所で、参照するメニュー配列が間違えているのを修正